### PR TITLE
feat: add `--dry` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 There are a bunch of solutions to install Go or manage Go versions outside of a package manager:
 [golang/dl](https://github.com/golang/dl), [getgo](https://github.com/golang/tools/tree/master/cmd/getgo), [gvm](https://github.com/moovweb/gvm), [goenv](https://github.com/syndbg/goenv), to name a few.
 
-
 `goup` is an attempt to fulfill the above features and is heavily inspired by [Rustup](https://rustup.rs/), [golang/dl](https://github.com/golang/dl), [goup](https://github.com/owenthereal/goup) and [getgo](https://github.com/golang/tools/tree/master/cmd/getgo).
+
+## Features
 
 ## Installation
 
@@ -30,9 +31,9 @@ cargo install goup-rs
 
 If you want to install manually, there are the steps:
 
-* Download the latest `goup` from `https://github.com/thinkgos/goup-rs/releases`
-* Drop the `goup` executable to your `PATH` and make it executable: `mv GOUP_BIN /usr/local/bin/goup && chmod +x /usr/local/bin/goup`
-* Add the Go bin directory to your shell startup script: `echo 'export PATH="$HOME/.goup/current/bin:$PATH"' >> ~/.bashrc`
+- Download the latest `goup` from `https://github.com/thinkgos/goup-rs/releases`
+- Drop the `goup` executable to your `PATH` and make it executable: `mv GOUP_BIN /usr/local/bin/goup && chmod +x /usr/local/bin/goup`
+- Add the Go bin directory to your shell startup script: `echo 'export PATH="$HOME/.goup/current/bin:$PATH"' >> ~/.bashrc`
 
 ## Quick Start
 
@@ -55,15 +56,15 @@ $ GOUP_GO_HOST=https://golang.google.cn goup install 1.21.4
 
 ## How it works
 
-* `goup completion <SHELL>` Generate the autocompletion script for the specified shell.
-* `goup [help]` Print this message or the help of the given subcommand(s).
-* `goup install/update [VERSION]` downloads specified version of Go to`$HOME/.goup/<VERSION>/go` and symlinks it to `$HOME/.goup/current`.
-* `goup use/set <VERSION>` switches to selected Go version.
-* `goup ls/list/show` list all installed Go version located at `$HOME/.goup`.
-* `goup remove/rm [VERSION]...` removes the specified Go version.
-* `goup search [VERSION]` lists all available Go versions from `https://golang.org/dl`.
-* `goup upgrade` upgrades `goup`.
-* `goup init` write all necessary environment variables and values to `$HOME/.goup/env`.
+- `goup completion <SHELL>` Generate the autocompletion script for the specified shell.
+- `goup [help]` Print this message or the help of the given subcommand(s).
+- `goup install/update [VERSION]` downloads specified version of Go to`$HOME/.goup/<VERSION>/go` and symlinks it to `$HOME/.goup/current`.
+- `goup use/set <VERSION>` switches to selected Go version.
+- `goup ls/list/show` list all installed Go version located at `$HOME/.goup`.
+- `goup remove/rm [VERSION]...` removes the specified Go version.
+- `goup search [VERSION]` lists all available Go versions from `https://golang.org/dl`.
+- `goup upgrade` upgrades `goup`.
+- `goup init` write all necessary environment variables and values to `$HOME/.goup/env`.
 
 ## License
 

--- a/goup/src/command/install.rs
+++ b/goup/src/command/install.rs
@@ -16,6 +16,9 @@ pub struct Install {
     /// host that is used to download Go.
     #[arg(long, default_value_t = consts::GO_HOST.to_owned(), env = consts::GOUP_GO_HOST)]
     host: String,
+    /// only just install the version, but do not switch.
+    #[arg(long, default_value_t = false)]
+    dry: bool,
 }
 
 impl Run for Install {
@@ -31,6 +34,9 @@ impl Run for Install {
         } else {
             Downloader::install_go_version(&version)?;
         }
-        Version::set_go_version(&version)
+        if !self.dry {
+            Version::set_go_version(&version)?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
fix #32, add `--dry` flag,  now we can `goup install 1.21.4 --dry` to just install a version, ignore switch to the version 