### PR TITLE
Fix: fix failed to unpack go version 1.20.x and below

### DIFF
--- a/goup-downloader/src/archived/zip.rs
+++ b/goup-downloader/src/archived/zip.rs
@@ -21,6 +21,10 @@ impl Unpacker for Zip {
             let path = file.mangled_name();
 
             let dest_file = dest_dir.as_ref().join(path);
+            if file.is_dir() {
+                fs::create_dir_all(&dest_file)?;
+                continue;
+            }
             let parent = dest_file.parent().ok_or(anyhow!("No parent path found"))?;
             if !parent.exists() {
                 fs::create_dir_all(parent)?;


### PR DESCRIPTION
ref to https://github.com/zip-rs/zip2/blob/HEAD/examples/extract.rs, add a dir judgement before extracting;