### PR TITLE
fix: GOUP_HOME variable should not be local

### DIFF
--- a/goup/setup_env_unix
+++ b/goup/setup_env_unix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-local GOUP_HOME=${GOUP_HOME:-$HOME/.goup}
+GOUP_HOME=${GOUP_HOME:-$HOME/.goup}
 
 # goup shell setup
 # affix colons on either side of $PATH to simplify matching


### PR DESCRIPTION
bash and most other shells use local variables only in shell functions and GOUP_HOME should not be local as its a script level variable.

This patch will fix the following error when env file is sourced:

```bash
$ source $HOME/.goup/env
bash: local: can only be used in a function
$

$ source $HOME/.goup/env
$
```