### PR TITLE
[Refactor]Remove unpack go prefix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "goup-rs"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goup-rs"
-version = "0.13.3"
+version = "0.14.0"
 authors = ["thinkgo <thinkgo@aliyun.com>"]
 edition = "2024"
 rust-version = "1.86"

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -56,7 +56,7 @@ impl Downloader {
             ));
         }
 
-        let gotip_go = Dir::goup_home()?.version_go("gotip");
+        let gotip_go = Dir::goup_home()?.version("gotip");
         let gotip_git = gotip_go.join_path(".git");
         // gotip is not clone from source
         if !gotip_git.exists() {

--- a/src/downloader/tgz.rs
+++ b/src/downloader/tgz.rs
@@ -21,12 +21,16 @@ impl Unpacker for Tgz {
             let mut entry = entry?;
             let path = entry.path()?;
 
-            let dest_file = dest_dir.as_ref().join(path);
-            let parent = dest_file.parent().ok_or(anyhow!("No parent path found"))?;
-            if !parent.exists() {
-                fs::create_dir_all(parent)?;
+            if let Some(path_str) = path.to_str() {
+                if let Some(relative_path) = path_str.strip_prefix("go/") {
+                    let dest_file = dest_dir.as_ref().join(relative_path);
+                    let parent = dest_file.parent().ok_or(anyhow!("No parent path found"))?;
+                    if !parent.exists() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    entry.unpack(dest_file)?;
+                }
             }
-            entry.unpack(dest_file)?;
         }
         Ok(())
     }

--- a/src/downloader/zip.rs
+++ b/src/downloader/zip.rs
@@ -20,18 +20,24 @@ impl Unpacker for Zip {
             let mut file = archive.by_index(i)?;
             let path = file.mangled_name();
 
-            let dest_file = dest_dir.as_ref().join(path);
-            if file.is_dir() {
-                fs::create_dir_all(&dest_file)?;
-                continue;
-            }
-            let parent = dest_file.parent().ok_or(anyhow!("No parent path found"))?;
-            if !parent.exists() {
-                fs::create_dir_all(parent)?;
-            }
+            if let Some(path_str) = path.to_str() {
+                // 标准化路径分隔符并检查是否在 go/ 目录下
+                let normalized_path = path_str.replace('\\', "/");
+                if let Some(relative_path) = normalized_path.strip_prefix("go/") {
+                    let dest_file = dest_dir.as_ref().join(relative_path);
+                    if file.is_dir() {
+                        fs::create_dir_all(&dest_file)?;
+                        continue;
+                    }
+                    let parent = dest_file.parent().ok_or(anyhow!("No parent path found"))?;
+                    if !parent.exists() {
+                        fs::create_dir_all(parent)?;
+                    }
 
-            let mut output_file = File::create(dest_file)?;
-            io::copy(&mut file, &mut output_file)?;
+                    let mut output_file = File::create(dest_file)?;
+                    io::copy(&mut file, &mut output_file)?;
+                }
+            }
         }
         Ok(())
     }

--- a/src/version/dir.rs
+++ b/src/version/dir.rs
@@ -80,12 +80,6 @@ impl Dir {
         d.push(p);
         d
     }
-    /// Extends `self` with `{version}/go`
-    pub fn version_go<P: AsRef<Path>>(&self, ver: P) -> Self {
-        let mut d = self.join_path(ver);
-        d.push("go");
-        d
-    }
     /// Extends `self` with `{version}/.unpacked-success`
     fn version_dot_unpacked_success<P: AsRef<Path>>(&self, ver: P) -> Self {
         let mut d = self.join_path(ver);
@@ -186,18 +180,6 @@ mod tests {
         assert_eq!(
             Dir::new(home_dir).version("go1.21.2").as_ref(),
             Path::new("/home/dev/.goup/go1.21.2")
-        );
-        assert_eq!(
-            Dir::new(home_dir).version_go("go1.21.2").as_ref(),
-            Path::new("/home/dev/.goup/go1.21.2/go")
-        );
-        assert_eq!(
-            Dir::new(home_dir).version_go("go1.21.2").as_ref(),
-            Path::new("/home/dev/.goup/go1.21.2/go")
-        );
-        assert_eq!(
-            Dir::new(home_dir).version_go("go1.21.2").as_ref(),
-            Path::new("/home/dev/.goup/go1.21.2/go")
         );
     }
 


### PR DESCRIPTION
Breakchange: 
    refator unpack tgz/zip, always under `go1.xx`(previous `go1.xx/go`).
    upgrade from v0.13.x or below, remove `$GOUP_HOME/.goup/gox.xx.x` file. reinstall go version can resolve this break change.