### PR TITLE
feat(command/oneself): dont update or uninstall when compiled with no-self-update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ build = "build.rs"
 name = "goup"
 path = "src/main.rs"
 
+[features]
+default = []
+no-self-update = []
+
 [build-dependencies]
 version_check = "0.9"
 shadow-rs = "1.4"

--- a/src/command/oneself.rs
+++ b/src/command/oneself.rs
@@ -40,6 +40,11 @@ impl Run for Oneself {
     fn run(&self) -> Result<(), anyhow::Error> {
         match self.command {
             Command::Update => {
+                if cfg!(feature = "no-self-update") {
+                    log::warn!("self-update is disabled for this build of goup");
+                    log::warn!("you should use your system package manager to update goup");
+                    return Ok(());
+                }
                 let cmd = Cli::command();
                 let status = Update::configure()
                     .repo_owner("thinkgos")
@@ -53,6 +58,11 @@ impl Run for Oneself {
                 log::info!("Update status: `v{}`!", status.version());
             }
             Command::Uninstall(ref arg) => {
+                if cfg!(feature = "no-self-update") {
+                    log::warn!("self-uninstall is disabled for this build of goup");
+                    log::warn!("you should use your system package manager to uninstall goup");
+                    return Ok(());
+                }
                 let confirmation = arg.no_confirm
                     || Confirm::with_theme(&ColorfulTheme::default())
                         .with_prompt("Do you want to uninstall goup?")


### PR DESCRIPTION
Hi, thanks for creating this neat tool, I have been using it for a while now and decided to make an [AUR Package](https://aur.archlinux.org/packages/goup-rs) for it.

However, I noticed that `goup` currently does not offer an option to restrict/disable the `self update` option, like f.E. `rustup` does [like this](https://github.com/rust-lang/rustup/blob/16fcef2e57830971c3f54bbd5177fbe1c1d0cb67/src/cli/self_update.rs#L987).

I decided to adapt these changes into `goup`, which now allows for a feature flag to be set at build time.

```
> cargo build --features no-self-update
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
> goup self uninstall
[2025-10-24 22:47:02 WARN] self-uninstall is disabled for this build of goup
[2025-10-24 22:47:02 WARN] you should use your system package manager to uninstall goup
```

Feel free to adapt/merge/close, have a nice day. :)

## What does this PR change/add?

This PR adds the ability for packagers of this tool to pass `--features no-self-update` during compilation, to restrict `goup` from updating itself if it was installed through the system package manager.

## Have i tested my changes?

Yes, on an Arch Linux system using `rust-1.90.0-stable`.