### PR TITLE
  fix: avoid selecting MSI asset in self update on Windows

### DIFF
--- a/src/command/oneself.rs
+++ b/src/command/oneself.rs
@@ -49,6 +49,7 @@ impl Run for Oneself {
                 let status = Update::configure()
                     .repo_owner("thinkgos")
                     .repo_name("goup-rs")
+                    .identifier(self_update_asset_identifier())
                     .bin_name(cmd.get_name())
                     .show_download_progress(true)
                     .no_confirm(true)
@@ -77,6 +78,17 @@ impl Run for Oneself {
             }
         }
         Ok(())
+    }
+}
+
+fn self_update_asset_identifier() -> &'static str {
+    #[cfg(windows)]
+    {
+        ".zip"
+    }
+    #[cfg(not(windows))]
+    {
+        ".tar.gz"
     }
 }
 


### PR DESCRIPTION
 ## 问题背景

  在 Windows 上执行 `goup self update` 后，可能出现：
```shell
 goup
  ResourceUnavailable: Program 'goup.exe' failed to run: An error occurred trying to start process 'D:\Rust\cargo\bin\goup.exe' with working directory 'C:\Users\zcg'. The
  specified executable is not a valid application for this OS platform.At line:1 char:1
  + goup
  + ~~~~.
```

  这会导致 `goup.exe` 无法运行。

  ## 根因分析

  `self_update` 按“目标三元组匹配到的第一个资产”选择下载文件。
  Windows 发布资产同时包含 `.msi` 和 `.zip`，当误选 `.msi` 时，可能把 MSI 内容替换到 `goup.exe`，从而损坏可执行文件。

  ## 修复内容

  - 在自更新流程中增加资产类型过滤，避免误选安装包资产。
  - 平台策略：
    - Windows 仅匹配 `.zip`
    - 非 Windows 匹配 `.tar.gz`

  实现位置：
  - `src/command/oneself.rs:52`
  - `src/command/oneself.rs:84`

  ## 验证结果

  已在本地执行并通过：

  - `cargo check --all`
  - `cargo test --all-features`

  ## 影响范围

  仅影响 `self update` 的发布资产选择逻辑，不改变其他命令行为。
本pr由codex cli gpt5.3codex提交